### PR TITLE
Added 'stroke' color and width to give text an outline

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ file_path     | String  | Yes        | null
 text          | String  | Not Really | ""
 font_style      | String     | No         | "calibri"
 font_color     | String  | No         | "white"
+stroke_color    | String | No | "transparent"
 font_size      | Int     | No         | 32
+stroke_width | Int | No | 1
 alignment_x    | String  | No         | "middle"
 alignment_y   | String  | No         | "bottom"
 write_path    | String  | No         | "/gif-with-custom-text.gif"
@@ -67,6 +69,14 @@ should contain letters and numbers
 &nbsp;
 # font_style
 Any installed font
+
+&nbsp;
+# stroke_color
+Color of the stroke, leave as "transparent" for no stroke. Accepts any [CSS Color](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value).
+
+&nbsp;
+# stroke_width
+Number specifying the line width of drawn text, in 'coordinate space units'
 
 &nbsp;
 # alignment

--- a/text-on-gif.js
+++ b/text-on-gif.js
@@ -18,7 +18,9 @@ class TextOnGif extends EventEmitter{
             file_path,
             font_style,
             font_color,
+            stroke_color,
             font_size,
+            stroke_width, 
             alignment_x,
             alignment_y,
             offset_x,
@@ -31,7 +33,9 @@ class TextOnGif extends EventEmitter{
         this.#file_path = file_path;
         this.font_style = font_style || "arial";
         this.font_color = font_color || "black";
+        this.stroke_color = stroke_color || "transparent";
         this.font_size = font_size || "32px";
+        this.stroke_width = stroke_width || 1;
         this.alignment_x = alignment_x || "center";
         this.alignment_y = alignment_y || "bottom";
         this.offset_x = offset_x || 10;
@@ -90,7 +94,9 @@ class TextOnGif extends EventEmitter{
         const ctx = canvas.getContext('2d',{alpha: false});
 
         ctx.fillStyle = this.font_color;
+        ctx.strokeStyle = this.stroke_color;
         ctx.font = this.font_size + ' ' + this.font_style;
+        ctx.lineWidth = this.stroke_width
 
         if(write_path && !get_as_buffer){
             const writeStream = fs.createWriteStream(write_path);
@@ -138,6 +144,7 @@ class TextOnGif extends EventEmitter{
             
         for(let index = 0; index < this.extractedFrames.length; index++) {
             ctx.drawImage(this.extractedFrames[index].imageData, 0, 0);
+            ctx.strokeText(text,x,y);
             ctx.fillText(text,x,y);
             encoder.setDelay(this.extractedFrames[index].delay);
             encoder.setDispose(this.extractedFrames[index].disposal);


### PR DESCRIPTION
This is in response to issue #8.

I tested it using your example script from the readme